### PR TITLE
thirdparty.yaml: add comsat-dropwizard

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -1,3 +1,12 @@
+- name: comsat-dropwizard
+  url: http://docs.paralleluniverse.co/comsat/#dropwizard
+  description: Handle many more concurrent requests with by replacing heavyweight Java threads with featherweight Quasar fibers
+  dropwizard: 0.8
+  license: Apache 2.0 or EPL v1.0
+  maven:
+    url: https://repo1.maven.org/maven2/co/paralleluniverse/comsat-dropwizard
+    groupId: co.paralleluniverse
+    artifactId: comsat-dropwizard
 - name: wizard-in-a-box
   url: https://github.com/rvs-fluid-it/wizard-in-a-box
   description: Adapter to deploy on a 3.0 servlet container (Tomcat, jBoss, ...)


### PR DESCRIPTION
I'd like to add Parallel Universe's `comsat-dropwizard` integration to the list of 3rd-party modules.
